### PR TITLE
Use Go Style Symbol Names

### DIFF
--- a/evaluate_test.go
+++ b/evaluate_test.go
@@ -20,14 +20,14 @@ func TestEvaluate(t *testing.T) {
 		{
 			"top stack value is true",
 			args{bytes.NewReader([]byte{
-				ops.OP_TRUE,
+				ops.OpTrue,
 			})},
 			false,
 		},
 		{
 			"top value is false",
 			args{bytes.NewReader([]byte{
-				ops.OP_FALSE,
+				ops.OpFalse,
 			})},
 			true,
 		},

--- a/ops/constants.go
+++ b/ops/constants.go
@@ -5,30 +5,31 @@ import (
 	"fmt"
 )
 
+// TODO(benjic): Document the operation symbols
 const (
-	OP_0         uint8 = 0x00
-	OP_FALSE     uint8 = 0x00
-	OP_PUSHDATA1 uint8 = 0x4c
-	OP_PUSHDATA2 uint8 = 0x4d
-	OP_PUSHDATA4 uint8 = 0x4e
-	OP_1NEGATE   uint8 = 0x4f
-	OP_TRUE      uint8 = 0x51
-	OP_1         uint8 = 0x51
-	OP_2         uint8 = 0x52
-	OP_3         uint8 = 0x53
-	OP_4         uint8 = 0x54
-	OP_5         uint8 = 0x55
-	OP_6         uint8 = 0x56
-	OP_7         uint8 = 0x57
-	OP_8         uint8 = 0x58
-	OP_9         uint8 = 0x59
-	OP_10        uint8 = 0x5a
-	OP_11        uint8 = 0x5b
-	OP_12        uint8 = 0x5c
-	OP_13        uint8 = 0x5d
-	OP_14        uint8 = 0x5e
-	OP_15        uint8 = 0x5f
-	OP_16        uint8 = 0x60
+	Op0         uint8 = 0x00
+	OpFalse     uint8 = 0x00
+	OpPushData1 uint8 = 0x4c
+	OpPushData2 uint8 = 0x4d
+	OpPushData4 uint8 = 0x4e
+	Op1Negate   uint8 = 0x4f
+	OpTrue      uint8 = 0x51
+	Op1         uint8 = 0x51
+	Op2         uint8 = 0x52
+	Op3         uint8 = 0x53
+	Op4         uint8 = 0x54
+	Op5         uint8 = 0x55
+	Op6         uint8 = 0x56
+	Op7         uint8 = 0x57
+	Op8         uint8 = 0x58
+	Op9         uint8 = 0x59
+	Op10        uint8 = 0x5a
+	Op11        uint8 = 0x5b
+	Op12        uint8 = 0x5c
+	Op13        uint8 = 0x5d
+	Op14        uint8 = 0x5e
+	Op15        uint8 = 0x5f
+	Op16        uint8 = 0x60
 )
 
 var (

--- a/ops/logic.go
+++ b/ops/logic.go
@@ -2,8 +2,9 @@ package ops
 
 import "bytes"
 
+// TODO(benjic): Document the operation symbols
 const (
-	OP_EQUAL uint8 = 0x87
+	OpEqual uint8 = 0x87
 )
 
 func opEqual(c Context) error {

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -8,43 +8,43 @@ var (
 	defaultProvider = &provider{
 		map[uint8]Op{
 			// Constants
-			OP_FALSE:     opFalse,
-			OP_PUSHDATA1: createOpPushNBytes(1),
-			OP_PUSHDATA2: createOpPushNBytes(2),
-			OP_PUSHDATA4: createOpPushNBytes(4),
-			OP_1NEGATE:   op1Negate,
-			OP_TRUE:      opTrue,
+			OpFalse:     opFalse,
+			OpPushData1: createOpPushNBytes(1),
+			OpPushData2: createOpPushNBytes(2),
+			OpPushData4: createOpPushNBytes(4),
+			Op1Negate:   op1Negate,
+			OpTrue:      opTrue,
 
 			// Logic
-			OP_EQUAL: opEqual,
+			OpEqual: opEqual,
 
 			// Stack
-			OP_TOALTSTACK:   opToAltStack,
-			OP_FROMALTSTACK: opFromAltStack,
-			OP_IFDUP:        opIfDup,
-			OP_DEPTH:        opDepth,
-			OP_DUP:          opDup,
-			OP_NIP:          opNip,
+			OpToAltStack:   opToAltStack,
+			OpFromAltStack: opFromAltStack,
+			OpIfDup:        opIfDup,
+			OpDepth:        opDepth,
+			OpDup:          opDup,
+			OpNip:          opNip,
 		},
 		map[string]uint8{
 			// Constants
-			"OP_FALSE":     OP_FALSE,
-			"OP_PUSHDATA1": OP_PUSHDATA1,
-			"OP_PUSHDATA2": OP_PUSHDATA2,
-			"OP_PUSHDATA4": OP_PUSHDATA4,
-			"OP_1NEGATE":   OP_1NEGATE,
-			"OP_TRUE":      OP_TRUE,
+			"OP_FALSE":     OpFalse,
+			"OP_PUSHDATA1": OpPushData1,
+			"OP_PUSHDATA2": OpPushData2,
+			"OP_PUSHDATA4": OpPushData4,
+			"OP_1NEGATE":   Op1Negate,
+			"OP_TRUE":      OpTrue,
 
 			// Logic
-			"OP_EQUAL": OP_EQUAL,
+			"OP_EQUAL": OpEqual,
 
 			// Stack
-			"OP_TOALTSTACK":   OP_TOALTSTACK,
-			"OP_FROMALTSTACK": OP_FROMALTSTACK,
-			"OP_IFDUP":        OP_IFDUP,
-			"OP_DEPTH":        OP_DEPTH,
-			"OP_DUP":          OP_DUP,
-			"OP_NIP":          OP_NIP,
+			"OP_TOALTSTACK":   OpToAltStack,
+			"OP_FROMALTSTACK": OpFromAltStack,
+			"OP_IFDUP":        OpIfDup,
+			"OP_DEPTH":        OpDepth,
+			"OP_DUP":          OpDup,
+			"OP_NIP":          OpNip,
 		},
 	}
 
@@ -57,7 +57,7 @@ func init() {
 		defaultProvider.ops[i] = createOpPushNBytes(i)
 	}
 
-	for i := OP_2; i <= OP_16; i++ {
+	for i := Op2; i <= Op16; i++ {
 		defaultProvider.ops[i] = createOpPushN(i)
 	}
 }

--- a/ops/stack.go
+++ b/ops/stack.go
@@ -5,15 +5,16 @@ import (
 	"encoding/binary"
 )
 
+// TODO(benjic): Document the operation symbols
 const (
-	OP_TOALTSTACK   uint8 = 0x6b
-	OP_FROMALTSTACK uint8 = 0x6c
-	OP_IFDUP        uint8 = 0x73
-	OP_DEPTH        uint8 = 0x74
-	OP_DROP         uint8 = 0x75
-	OP_DUP          uint8 = 0x76
-	OP_NIP          uint8 = 0x77
-	OP_OVER         uint8 = 0x78
+	OpToAltStack   uint8 = 0x6b
+	OpFromAltStack uint8 = 0x6c
+	OpIfDup        uint8 = 0x73
+	OpDepth        uint8 = 0x74
+	OpDrop         uint8 = 0x75
+	OpDup          uint8 = 0x76
+	OpNip          uint8 = 0x77
+	OpOver         uint8 = 0x78
 )
 
 func opToAltStack(c Context) error {

--- a/parse_test.go
+++ b/parse_test.go
@@ -39,7 +39,7 @@ func TestParse(t *testing.T) {
 		{
 			"op",
 			args{"OP_FALSE"},
-			[]byte{ops.OP_FALSE},
+			[]byte{ops.OpFalse},
 			false,
 		},
 	}


### PR DESCRIPTION
The opcodes retained the bitcoin style camel case caps lock yelling. These should be updated to reflect Go style.