### PR TITLE
Apply simplified gofmt

### DIFF
--- a/ops/splice.go
+++ b/ops/splice.go
@@ -109,7 +109,7 @@ func opRight(c Context) error {
 		return ErrInvalidStackOperation
 	}
 
-	c.Push([]byte(in[size:len(in)]))
+	c.Push([]byte(in[size:]))
 	return nil
 }
 

--- a/ops/utils_test.go
+++ b/ops/utils_test.go
@@ -62,9 +62,9 @@ func stackWithNumbers(t *testing.T, ns ...int32) *stack {
 }
 
 type config struct {
-	stack    *stack
-	alt      *stack
-	buf      []byte
+	stack *stack
+	alt   *stack
+	buf   []byte
 }
 
 func runOpTests(t *testing.T, tests []opTests) {


### PR DESCRIPTION
The simplify parameter in gofmt allows for more idiomatic Go code. There are a few changes applied with this parameter.